### PR TITLE
Fix/paste

### DIFF
--- a/lib/web_console/templates/_inner_console_markup.html.erb
+++ b/lib/web_console/templates/_inner_console_markup.html.erb
@@ -5,4 +5,4 @@
   </div>
   <div class='console-inner'></div>
 </div>
-<input class='clipboard' type='text'>
+<textarea class='clipboard'>

--- a/lib/web_console/templates/_inner_console_markup.html.erb
+++ b/lib/web_console/templates/_inner_console_markup.html.erb
@@ -5,4 +5,3 @@
   </div>
   <div class='console-inner'></div>
 </div>
-<textarea class='clipboard'>

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -419,9 +419,7 @@ REPLConsole.prototype.install = function(container) {
   _this = this;
 
   var focusHiddenArea = function() {
-    // In order to ensure that the browser will fire clipboard events, we always need to have something selected
-    _this.clipboard.value = ' ';
-    _this.clipboard.focus().select();
+    _this.clipboard.focus();
   };
 
   // Set clipboard event listeners on the document. 
@@ -429,6 +427,7 @@ REPLConsole.prototype.install = function(container) {
     document.addEventListener(event, function(e) {
       console.log("clipboard event triggered:", event);
       focusHiddenArea();
+      console.log(_this.clipboard.value);
       _this.addToInput(_this.clipboard.value);
       e.preventDefault();
     });
@@ -566,10 +565,10 @@ REPLConsole.prototype.setInput = function(input, caretPos) {
  * Add some text to the existing input.
  */
 REPLConsole.prototype.addToInput = function(val, caretPos) {
-  console.log("addToInput:", val);
   caretPos = caretPos || this._caretPos;
   var before = this._input.substring(0, caretPos);
   var after = this._input.substring(caretPos, this._input.length);
+  console.log("addToInput:", before, after);
   var newInput =  before + val + after;
   this.setInput(newInput, caretPos + val.length);
 };

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -420,7 +420,7 @@ REPLConsole.prototype.install = function(container) {
 
   var focusHiddenArea = function() {
     // In order to ensure that the browser will fire clipboard events, we always need to have something selected
-    _this.clipboard.val(' ');
+    _this.clipboard.value = ' ';
     _this.clipboard.focus().select();
   };
 

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -346,9 +346,7 @@ REPLConsole.prototype.install = function(container) {
   
     // Get the clipboard data
     let paste = (e.clipboardData || window.clipboardData).getData('text');
-    console.log('pasted =>', paste);
-    // Do something with paste like remove non-UTF-8 characters
-    paste = paste.replace(/[^\x20-\xFF]/gi, '');
+    console.log(paste);
     
     _this.addToInput(paste);
   });

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -418,21 +418,6 @@ REPLConsole.prototype.install = function(container) {
   this.clipboard = findChild(container, 'clipboard');
   _this = this;
 
-  var focusHiddenArea = function() {
-    _this.clipboard.focus();
-  };
-
-  // Set clipboard event listeners on the document. 
-  ['cut', 'copy', 'paste'].forEach(function(event) {
-    document.addEventListener(event, function(e) {
-      console.log("clipboard event triggered:", event);
-      focusHiddenArea();
-      console.log(_this.clipboard.value);
-      _this.addToInput(_this.clipboard.value);
-      e.preventDefault();
-    });
-  });
-
   this.suggestWait = 1500;
   this.newPromptBox();
   this.insertCss();
@@ -761,21 +746,23 @@ REPLConsole.prototype.onKeyDown = function(ev) {
       break;
   }
 
-  // if (ev.ctrlKey || ev.metaKey) {
-  //   if (ev.keyCode == 86) {
-  //     // Set focus to our clipboard when they hit the "v" key
-  //     this.clipboard.focus();
+  if (ev.ctrlKey || ev.metaKey) {
+    if (ev.keyCode == 86) {
+      // Set focus to our clipboard when they hit the "v" key
+      this.clipboard.value = "";
+      this.clipboard.focus();
 
-  //     // Pasting to clipboard doesn't happen immediately,
-  //     // so we have to wait for a while to get the pasted text.
-  //     var _this = this;
-  //     setTimeout(function() {
-  //       _this.addToInput(_this.clipboard.value);
-  //       _this.clipboard.value = "";
-  //       _this.clipboard.blur();
-  //     }, 10);
-  //   }
-  // }
+      // Pasting to clipboard doesn't happen immediately,
+      // so we have to wait for a while to get the pasted text.
+      var _this = this;
+      setTimeout(function() {
+        console.log(_this.clipboard.value);
+        _this.addToInput(_this.clipboard.value);
+        _this.clipboard.value = "";
+        _this.clipboard.blur();
+      }, 10);
+    }
+  }
 
   ev.stopPropagation();
 };

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -344,7 +344,7 @@ REPLConsole.prototype.install = function(container) {
     ev.stopPropagation();
   
     // Get the clipboard data
-    let paste = (ev.clipboardData || window.clipboardData).getData('text');
+    var paste = (ev.clipboardData || window.clipboardData).getData('text');
     _this.addToInput(paste);
   });
 

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -749,7 +749,6 @@ REPLConsole.prototype.onKeyDown = function(ev) {
   if (ev.ctrlKey || ev.metaKey) {
     if (ev.keyCode == 86) {
       // Set focus to our clipboard when they hit the "v" key
-      this.clipboard.value = "";
       this.clipboard.focus();
 
       // Pasting to clipboard doesn't happen immediately,
@@ -760,7 +759,7 @@ REPLConsole.prototype.onKeyDown = function(ev) {
         _this.addToInput(_this.clipboard.value);
         _this.clipboard.value = "";
         _this.clipboard.blur();
-      }, 10);
+      }, 1);
     }
   }
 

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -415,8 +415,7 @@ REPLConsole.prototype.install = function(container) {
   this.container = container;
   this.outer = consoleOuter;
   this.inner = findChild(this.outer, 'console-inner');
-  this.clipboard = findChild(container, 'clipboard');
-  var _this = this;
+  this.clipboard = document.querySelector('.clipboard');
 
   this.suggestWait = 1500;
   this.newPromptBox();
@@ -749,7 +748,6 @@ REPLConsole.prototype.onKeyDown = function(ev) {
   if (ev.ctrlKey || ev.metaKey) {
     if (ev.keyCode == 86) {
       // Set focus to our clipboard when they hit the "v" key
-      this.clipboard.value = "";
       this.clipboard.focus();
 
       // Pasting to clipboard doesn't happen immediately,
@@ -760,7 +758,7 @@ REPLConsole.prototype.onKeyDown = function(ev) {
         _this.addToInput(_this.clipboard.value);
         _this.clipboard.value = "";
         _this.clipboard.blur();
-      }, 1);
+      }, 10);
     }
   }
 

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -416,6 +416,24 @@ REPLConsole.prototype.install = function(container) {
   this.outer = consoleOuter;
   this.inner = findChild(this.outer, 'console-inner');
   this.clipboard = findChild(container, 'clipboard');
+  _this = this;
+
+  var focusHiddenArea = function() {
+    // In order to ensure that the browser will fire clipboard events, we always need to have something selected
+    _this.clipboard.val(' ');
+    _this.clipboard.focus().select();
+  };
+
+  // Set clipboard event listeners on the document. 
+  ['cut', 'copy', 'paste'].forEach(function(event) {
+    document.addEventListener(event, function(e) {
+      console.log("clipboard event triggered:", event);
+      focusHiddenArea();
+      _this.addToInput(_this.clipboard.value);
+      e.preventDefault();
+    });
+  });
+
   this.suggestWait = 1500;
   this.newPromptBox();
   this.insertCss();
@@ -548,6 +566,7 @@ REPLConsole.prototype.setInput = function(input, caretPos) {
  * Add some text to the existing input.
  */
 REPLConsole.prototype.addToInput = function(val, caretPos) {
+  console.log("addToInput:", val);
   caretPos = caretPos || this._caretPos;
   var before = this._input.substring(0, caretPos);
   var after = this._input.substring(caretPos, this._input.length);
@@ -743,21 +762,21 @@ REPLConsole.prototype.onKeyDown = function(ev) {
       break;
   }
 
-  if (ev.ctrlKey || ev.metaKey) {
-    if (ev.keyCode == 86) {
-      // Set focus to our clipboard when they hit the "v" key
-      this.clipboard.focus();
+  // if (ev.ctrlKey || ev.metaKey) {
+  //   if (ev.keyCode == 86) {
+  //     // Set focus to our clipboard when they hit the "v" key
+  //     this.clipboard.focus();
 
-      // Pasting to clipboard doesn't happen immediately,
-      // so we have to wait for a while to get the pasted text.
-      var _this = this;
-      setTimeout(function() {
-        _this.addToInput(_this.clipboard.value);
-        _this.clipboard.value = "";
-        _this.clipboard.blur();
-      }, 10);
-    }
-  }
+  //     // Pasting to clipboard doesn't happen immediately,
+  //     // so we have to wait for a while to get the pasted text.
+  //     var _this = this;
+  //     setTimeout(function() {
+  //       _this.addToInput(_this.clipboard.value);
+  //       _this.clipboard.value = "";
+  //       _this.clipboard.blur();
+  //     }, 10);
+  //   }
+  // }
 
   ev.stopPropagation();
 };

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -338,6 +338,21 @@ REPLConsole.prototype.uninstall = function() {
 REPLConsole.prototype.install = function(container) {
   var _this = this;
 
+  document.addEventListener('paste', (e) => {
+    console.log('in paste event', e);
+    // Prevent the default pasting event and stop bubbling
+    e.preventDefault();
+    e.stopPropagation();
+  
+    // Get the clipboard data
+    let paste = (e.clipboardData || window.clipboardData).getData('text');
+    console.log('pasted =>', paste);
+    // Do something with paste like remove non-UTF-8 characters
+    paste = paste.replace(/[^\x20-\xFF]/gi, '');
+    
+    _this.addToInput(paste);
+  });
+
   document.onkeydown = function(ev) {
     if (_this.focused) { _this.onKeyDown(ev); }
   };
@@ -552,7 +567,7 @@ REPLConsole.prototype.addToInput = function(val, caretPos) {
   caretPos = caretPos || this._caretPos;
   var before = this._input.substring(0, caretPos);
   var after = this._input.substring(caretPos, this._input.length);
-  console.log("addToInput:", before, after);
+  console.log("addToInput:", val);
   var newInput =  before + val + after;
   this.setInput(newInput, caretPos + val.length);
 };
@@ -746,23 +761,23 @@ REPLConsole.prototype.onKeyDown = function(ev) {
   }
 
   if (ev.ctrlKey || ev.metaKey) {
-    if (ev.keyCode == 86) {
-      // Set focus to our clipboard when they hit the "v" key
-      this.clipboard.focus();
+    // if (ev.keyCode == 86) {
+    //   // Set focus to our clipboard when they hit the "v" key
+    //   this.clipboard.focus();
 
-      // Pasting to clipboard doesn't happen immediately,
-      // so we have to wait for a while to get the pasted text.
-      var _this = this;
-      setTimeout(function() {
-        console.log(_this.clipboard.value);
-        _this.addToInput(_this.clipboard.value);
-        _this.clipboard.value = "";
-        _this.clipboard.blur();
-      }, 10);
-    }
+    //   // Pasting to clipboard doesn't happen immediately,
+    //   // so we have to wait for a while to get the pasted text.
+    //   var _this = this;
+    //   setTimeout(function() {
+    //     console.log(_this.clipboard.value);
+    //     _this.addToInput(_this.clipboard.value);
+    //     _this.clipboard.value = "";
+    //     _this.clipboard.blur();
+    //   }, 10);
+    // }
   }
-
-  ev.stopPropagation();
+  else
+    ev.stopPropagation();
 };
 
 /**

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -416,7 +416,7 @@ REPLConsole.prototype.install = function(container) {
   this.outer = consoleOuter;
   this.inner = findChild(this.outer, 'console-inner');
   this.clipboard = findChild(container, 'clipboard');
-  _this = this;
+  var _this = this;
 
   this.suggestWait = 1500;
   this.newPromptBox();
@@ -749,6 +749,7 @@ REPLConsole.prototype.onKeyDown = function(ev) {
   if (ev.ctrlKey || ev.metaKey) {
     if (ev.keyCode == 86) {
       // Set focus to our clipboard when they hit the "v" key
+      this.clipboard.value = "";
       this.clipboard.focus();
 
       // Pasting to clipboard doesn't happen immediately,

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -338,16 +338,13 @@ REPLConsole.prototype.uninstall = function() {
 REPLConsole.prototype.install = function(container) {
   var _this = this;
 
-  document.addEventListener('paste', (e) => {
-    console.log('in paste event', e);
+  document.addEventListener('paste', function(ev) {
     // Prevent the default pasting event and stop bubbling
-    e.preventDefault();
-    e.stopPropagation();
+    ev.preventDefault();
+    ev.stopPropagation();
   
     // Get the clipboard data
-    let paste = (e.clipboardData || window.clipboardData).getData('text');
-    console.log(paste);
-    
+    let paste = (ev.clipboardData || window.clipboardData).getData('text');
     _this.addToInput(paste);
   });
 
@@ -428,7 +425,6 @@ REPLConsole.prototype.install = function(container) {
   this.container = container;
   this.outer = consoleOuter;
   this.inner = findChild(this.outer, 'console-inner');
-  this.clipboard = document.querySelector('.clipboard');
 
   this.suggestWait = 1500;
   this.newPromptBox();
@@ -565,7 +561,6 @@ REPLConsole.prototype.addToInput = function(val, caretPos) {
   caretPos = caretPos || this._caretPos;
   var before = this._input.substring(0, caretPos);
   var after = this._input.substring(caretPos, this._input.length);
-  console.log("addToInput:", val);
   var newInput =  before + val + after;
   this.setInput(newInput, caretPos + val.length);
 };
@@ -755,27 +750,10 @@ REPLConsole.prototype.onKeyDown = function(ev) {
       break;
 
     default:
-      break;
+      return;
   }
 
-  if (ev.ctrlKey || ev.metaKey) {
-    // if (ev.keyCode == 86) {
-    //   // Set focus to our clipboard when they hit the "v" key
-    //   this.clipboard.focus();
-
-    //   // Pasting to clipboard doesn't happen immediately,
-    //   // so we have to wait for a while to get the pasted text.
-    //   var _this = this;
-    //   setTimeout(function() {
-    //     console.log(_this.clipboard.value);
-    //     _this.addToInput(_this.clipboard.value);
-    //     _this.clipboard.value = "";
-    //     _this.clipboard.blur();
-    //   }, 10);
-    // }
-  }
-  else
-    ev.stopPropagation();
+  ev.stopPropagation();
 };
 
 /**

--- a/lib/web_console/templates/style.css.erb
+++ b/lib/web_console/templates/style.css.erb
@@ -25,7 +25,6 @@
 .console .button { cursor: pointer; border-radius: 1px; font-family: monospace; font-size: 13px; width: 14px; height: 14px; line-height: 14px; text-align: center; color: #CCC; }
 .console .button:hover { background: #666; color: #FFF; }
 .console .button.close-button:hover { background: #966; }
-.console .clipboard { height: 0px; padding: 0px; margin: 0px; width: 0px; margin-left: -1000px; }
 .console .console-prompt-label { display: inline; color: #FFF; background: none repeat scroll 0% 0% #333; border: 0; padding: 0; }
 .console .console-prompt-display { display: inline; color: #FFF; background: none repeat scroll 0% 0% #333; border: 0; padding: 0; }
 .console.full-screen { height: 100%; }

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebConsole
-  VERSION = "3.7.0"
+  VERSION = "3.8.0"
 end

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebConsole
-  VERSION = "3.8.7"
+  VERSION = "3.8.8"
 end

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebConsole
-  VERSION = "3.8.4"
+  VERSION = "3.8.5"
 end

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebConsole
-  VERSION = "3.8.6"
+  VERSION = "3.8.7"
 end

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebConsole
-  VERSION = "3.8.0"
+  VERSION = "3.8.1"
 end

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebConsole
-  VERSION = "3.8.8"
+  VERSION = "3.8.9"
 end

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebConsole
-  VERSION = "3.8.5"
+  VERSION = "3.8.6"
 end

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebConsole
-  VERSION = "3.8.3"
+  VERSION = "3.8.4"
 end

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebConsole
-  VERSION = "3.8.1"
+  VERSION = "3.8.2"
 end

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebConsole
-  VERSION = "3.8.2"
+  VERSION = "3.8.3"
 end

--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -6,7 +6,7 @@ require "web_console/version"
 
 Gem::Specification.new do |s|
   s.name     = "web-console"
-  s.version  = "3.8.1"
+  s.version  = "3.8.2"
   s.authors  = ["Charlie Somerville", "Genadi Samokovarov", "Guillermo Iguaran", "Ryan Dao"]
   s.email    = ["charlie@charliesomerville.com", "gsamokovarov@gmail.com", "guilleiguaran@gmail.com", "daoduyducduong@gmail.com"]
   s.homepage = "https://github.com/rails/web-console"

--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -6,7 +6,7 @@ require "web_console/version"
 
 Gem::Specification.new do |s|
   s.name     = "web-console"
-  s.version  = "3.8.4"
+  s.version  = "3.8.5"
   s.authors  = ["Charlie Somerville", "Genadi Samokovarov", "Guillermo Iguaran", "Ryan Dao"]
   s.email    = ["charlie@charliesomerville.com", "gsamokovarov@gmail.com", "guilleiguaran@gmail.com", "daoduyducduong@gmail.com"]
   s.homepage = "https://github.com/rails/web-console"

--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -6,7 +6,7 @@ require "web_console/version"
 
 Gem::Specification.new do |s|
   s.name     = "web-console"
-  s.version  = "3.8.5"
+  s.version  = WebConsole::VERSION
   s.authors  = ["Charlie Somerville", "Genadi Samokovarov", "Guillermo Iguaran", "Ryan Dao"]
   s.email    = ["charlie@charliesomerville.com", "gsamokovarov@gmail.com", "guilleiguaran@gmail.com", "daoduyducduong@gmail.com"]
   s.homepage = "https://github.com/rails/web-console"

--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -6,7 +6,7 @@ require "web_console/version"
 
 Gem::Specification.new do |s|
   s.name     = "web-console"
-  s.version  = "3.8.3"
+  s.version  = "3.8.4"
   s.authors  = ["Charlie Somerville", "Genadi Samokovarov", "Guillermo Iguaran", "Ryan Dao"]
   s.email    = ["charlie@charliesomerville.com", "gsamokovarov@gmail.com", "guilleiguaran@gmail.com", "daoduyducduong@gmail.com"]
   s.homepage = "https://github.com/rails/web-console"

--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -6,7 +6,7 @@ require "web_console/version"
 
 Gem::Specification.new do |s|
   s.name     = "web-console"
-  s.version  = "3.8.2"
+  s.version  = "3.8.3"
   s.authors  = ["Charlie Somerville", "Genadi Samokovarov", "Guillermo Iguaran", "Ryan Dao"]
   s.email    = ["charlie@charliesomerville.com", "gsamokovarov@gmail.com", "guilleiguaran@gmail.com", "daoduyducduong@gmail.com"]
   s.homepage = "https://github.com/rails/web-console"

--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -6,7 +6,7 @@ require "web_console/version"
 
 Gem::Specification.new do |s|
   s.name     = "web-console"
-  s.version  = WebConsole::VERSION
+  s.version  = "3.8.0"
   s.authors  = ["Charlie Somerville", "Genadi Samokovarov", "Guillermo Iguaran", "Ryan Dao"]
   s.email    = ["charlie@charliesomerville.com", "gsamokovarov@gmail.com", "guilleiguaran@gmail.com", "daoduyducduong@gmail.com"]
   s.homepage = "https://github.com/rails/web-console"

--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -6,7 +6,7 @@ require "web_console/version"
 
 Gem::Specification.new do |s|
   s.name     = "web-console"
-  s.version  = "3.8.0"
+  s.version  = "3.8.1"
   s.authors  = ["Charlie Somerville", "Genadi Samokovarov", "Guillermo Iguaran", "Ryan Dao"]
   s.email    = ["charlie@charliesomerville.com", "gsamokovarov@gmail.com", "guilleiguaran@gmail.com", "daoduyducduong@gmail.com"]
   s.homepage = "https://github.com/rails/web-console"


### PR DESCRIPTION
Fixes pasting for multiline commands.

Previously, multiline commands would be serialized to a single line and fail at the server. This fixes that by using standard event listeners and removing DOM-based solution.

@bao Tagging you for review